### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,22 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  precommit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pip install -e .
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: recursive-complexity-check
+        name: Recursive Complexity Check
+        entry: recursive_complexity_check
+        language: python
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,11 @@ default_language_version:
   python: python3
 
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 ψₙ₊₁ := ΨAgent(ψₙ) = Reflect(Drift(Collapse(ψₙ)))
 
 ## Development
-Install pre-commit to run linting hooks:
+Install `pre-commit` and the local hooks:
 
 ```bash
 pip install pre-commit
+pip install -e .  # install recursive_complexity_check entry point
 pre-commit install
+```
+
+Run all checks manually with:
+
+```bash
+pre-commit run --all-files
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Echometamorphic
 ψₙ₊₁ := ΨAgent(ψₙ) = Reflect(Drift(Collapse(ψₙ)))
+
+## Development
+Install pre-commit to run linting hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/echometamorphic/recursive_complexity_check.py
+++ b/echometamorphic/recursive_complexity_check.py
@@ -1,0 +1,34 @@
+import ast
+import sys
+
+
+def _node_depth(node: ast.AST, level: int = 0) -> int:
+    """Return the depth of nested function definitions within a node."""
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        level += 1
+    max_child = level
+    for child in ast.iter_child_nodes(node):
+        max_child = max(max_child, _node_depth(child, level))
+    return max_child
+
+
+def check_file(filename: str, max_depth: int = 10) -> int:
+    with open(filename, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename=filename)
+    depth = _node_depth(tree)
+    if depth > max_depth:
+        print(f"{filename}: recursive complexity {depth} > {max_depth}")
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = argv or sys.argv[1:]
+    status = 0
+    for path in argv:
+        status |= check_file(path)
+    sys.exit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "echometamorphic"
+version = "0.1.0"
+description = "Echometamorphic utilities"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+recursive_complexity_check = "echometamorphic.recursive_complexity_check:main"


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- document pre-commit installation in README

## Testing
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68845666b9a8832bbd139fd044dd9f5b

## Summary by Sourcery

Add a .pre-commit-config.yaml file and update the README to guide developers through installing and enabling pre-commit hooks

New Features:
- Add pre-commit configuration with Black, isort, Flake8, MyPy, and a recursive complexity check

Documentation:
- Document pre-commit installation and setup in the README