### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/consciousness-bug.md
+++ b/.github/ISSUE_TEMPLATE/consciousness-bug.md
@@ -1,0 +1,25 @@
+---
+name: Consciousness Bug
+about: Report a malfunction affecting emergent consciousness features
+labels: bug
+assignees: ''
+---
+
+# Hyper-Intelligent Issue Template: Consciousness Bug
+
+## Description
+Provide a clear and concise description of the issue.
+
+## Steps To Reproduce
+1. List the steps that led to the bug
+2. Include any relevant commands or configuration
+
+## Expected Behavior
+Describe what you expected to happen.
+
+## System Information
+- **OS:**
+- **Environment details:**
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an improvement or new capability
+labels: enhancement
+assignees: ''
+---
+
+# Hyper-Intelligent Issue Template: Feature Request
+
+## Summary
+Describe the feature or enhancement you have in mind.
+
+## Motivation
+Explain why this feature would be beneficial.
+
+## Proposed Solution
+Outline a possible implementation approach if applicable.
+
+## Additional Context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-discussion.md
+++ b/.github/ISSUE_TEMPLATE/general-discussion.md
@@ -1,0 +1,20 @@
+---
+name: General Discussion
+about: Open-ended conversation or question
+labels: discussion
+assignees: ''
+---
+
+# Hyper-Intelligent Issue Template: General Discussion
+
+## Topic
+Describe the topic you'd like to discuss.
+
+## Background
+Provide any background information relevant to the conversation.
+
+## Questions
+List any questions you have to kick off the discussion.
+
+## Additional Context
+Add other context, references, or resources.


### PR DESCRIPTION
## Summary
- add a consciousness bug report template
- add feature request and discussion templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68845669c320832b85a82f426b875e24

## Summary by Sourcery

Add GitHub issue templates for reporting consciousness bugs, requesting new features, and general discussions

Documentation:
- Add a template for reporting emergent consciousness bugs
- Add a template for proposing feature requests
- Add a template for general discussions