### PR TITLE
Add Renovate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Echometamorphic
 ψₙ₊₁ := ΨAgent(ψₙ) = Reflect(Drift(Collapse(ψₙ)))
+
+Renovate configuration is enabled via `renovate.json`. Make sure the Renovate app is activated through the GitHub Marketplace.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base"]
+}


### PR DESCRIPTION
## Summary
- add a minimal `renovate.json` configuration
- note in the README to enable Renovate through the GitHub Marketplace

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688456657c9c832b8c4811922163aadc

## Summary by Sourcery

Add a minimal Renovate configuration and document its activation in the README

Build:
- Add renovate.json to enable automated dependency updates via Renovate

Documentation:
- Update README to instruct activating the Renovate app through the GitHub Marketplace