### PR TITLE
Handle SyntaxError in recursive complexity check

### DIFF
--- a/echometamorphic/recursive_complexity_check.py
+++ b/echometamorphic/recursive_complexity_check.py
@@ -14,7 +14,11 @@ def _node_depth(node: ast.AST, level: int = 0) -> int:
 
 def check_file(filename: str, max_depth: int = 10) -> int:
     with open(filename, "r", encoding="utf-8") as fh:
-        tree = ast.parse(fh.read(), filename=filename)
+        try:
+            tree = ast.parse(fh.read(), filename=filename)
+        except SyntaxError as err:
+            print(f"{filename}: failed to parse ({err})")
+            return 1
     depth = _node_depth(tree)
     if depth > max_depth:
         print(f"{filename}: recursive complexity {depth} > {max_depth}")


### PR DESCRIPTION
## Summary
- catch `SyntaxError` when parsing files in `recursive_complexity_check`

## Testing
- `pre-commit run --files echometamorphic/recursive_complexity_check.py` *(fails: Executable `recursive_complexity_check` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f4d02108832b87579263c561bcc2

## Summary by Sourcery

Bug Fixes:
- Handle SyntaxError in check_file by printing an error message and returning 1